### PR TITLE
Document `timeoutAction` and `invalidAction` fields on `endpoint`

### DIFF
--- a/docs/direct/api/v1.md
+++ b/docs/direct/api/v1.md
@@ -1411,7 +1411,9 @@ The properties of each endpoint type are listed below.
 | items[].action.playSound <br /> *optional* | The URL of the [sound](https://developer.simwood.com/docs/direct/api/v1/#sounds) to play before transferring. Only valid when type = transfer. <br /> *String* |  
 | items[].action.display <br /> *optional* | A string to prepend to the caller ID when transferring.  Only valid when type = transfer. <br /> *String* |  
 | items[].action.sound <br /> *required* | The URL of the [sound](https://developer.simwood.com/docs/direct/api/v1/#sounds) to play before hanging up. Only valid when type = playsound. <br /> *String* |  
-| timeout <br /> *required*     | The number of seconds to wait for a keypress after the initial message has been played (default 5). <br /> *Integer* |  
+| timeout <br /> *optional*     | The number of seconds to wait for a keypress after the initial message has been played (default 5). <br /> *Integer* |  
+| timeoutAction <br /> *optional* | The action to perform if the timeout is hit.  This takes the same structure as items[].action above (default is to hang up). <br /> *Object* |
+| invalidAction <br /> *optional* | The action to perform if an invalid key is pressed.  This takes the same structure as items[].action above (default is to hang up). <br /> *Object* |
 
 | Type: *mailbox*             |                                                                        |  
 | -------------               | ---                                                                    |  


### PR DESCRIPTION
Charles (from Simwood) told me about the `timeoutAction` and `invalidAction` fields on the IVR `endpoint`, so I've updated the docs with them.