### PR TITLE
Include endpointId parameter description for customer calls

### DIFF
--- a/docs/direct/api/v1.md
+++ b/docs/direct/api/v1.md
@@ -800,6 +800,7 @@ Making a GET request to the list resource will return a history of the calls mad
 | to                      | String  | Include only calls to a specific number. Currently supports exact match only (no wildcards).                                                                                                   |
 | direction               | String  | Include only calls in a specific direction (in/out).                                                                                                                                           |
 | includeLocal            | Boolean | Whether or not to include local (internal) calls. Default is 'false'. Note: only the outbound record is included for calls between endpoints, as the inbound record would be an exact replica. |
+| endpointId              | Integer | Only include calls involving a specific endpoint ID. |
 
 
 ```


### PR DESCRIPTION
Mention the `endpointId` filter when listing customer calls.